### PR TITLE
Remove stashing from build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,6 @@ node('rhel7'){
 		stage('Snapshot') {
 			def filesToPush = findFiles(glob: '**.vsix')
 			sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${filesToPush[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-middleware-tools/"
-			stash name:'vsix', includes:filesToPush[0].path
 		}
 	}
 
@@ -51,7 +50,6 @@ node('rhel7'){
 		}
 
 		stage("Publish to Marketplace") {
-            unstash 'vsix'
             withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
                 def vsix = findFiles(glob: '**.vsix')
                 sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"


### PR DESCRIPTION
because it now runs on a single machine and doesn't need to transfer artifacts