### PR TITLE
The deprecated "java.home" configuration tag has been replaced.

### DIFF
--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -43,7 +43,7 @@ function checkJavaRuntime(): Promise<string> {
         let source: string;
         let javaHome: string | undefined = readJavaConfig();
         if (javaHome) {
-            source = 'The java.home variable defined in VS Code settings';
+            source = 'The java.jdt.ls.java.home variable defined in VS Code settings';
         } else {
             javaHome = process.env.JDK_HOME;
             if (javaHome) {
@@ -76,7 +76,7 @@ function checkJavaRuntime(): Promise<string> {
 
 function readJavaConfig(): string {
     const config = workspace.getConfiguration();
-    return config.get<string>('java.home', '');
+    return config.get<string>('java.jdt.ls.java.home', '');
 }
 
 function checkJavaVersion(javaHome: string): Promise<number> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,8 +37,8 @@ export function start(stdoutCallback: (data: string) => void,
                             vscode.commands.executeCommand('vscode.open', btnSelected.openUrl);
                         } else {
                             vscode.window.showInformationMessage(
-                                `To configure Java for Server Connector Extension add "java.home" property to your settings file
-                        (ex. "java.home": "/usr/local/java/jdk1.8.0_45").`);
+                                `To configure Java for Server Connector Extension add "java.jdt.ls.java.home" property to your settings file
+                        (ex. "java.jdt.ls.java.home": "/usr/local/java/jdk1.8.0_45").`);
                             vscode.commands.executeCommand(
                                 'workbench.action.openSettingsJson'
                             );


### PR DESCRIPTION
The deprecated _**"java.home"**_ configuration tag has been replaced by _**"java.jdt.ls.java.home"**_.

This configuration tag is already deprecated in current versions of vscode with the proper java extensions installed, the following annoying message is displayed _**"This setting is deprecated, please use 'java.jdt.ls.java.home' instead."**_

_This is my first pull request, I'm sorry if I'm missing something! I am a Brazilian programmer_ :brazil:.