### PR TITLE
Fix release script empty version display

### DIFF
--- a/npmUpversionMicroTagPush.sh
+++ b/npmUpversionMicroTagPush.sh
@@ -59,14 +59,12 @@ echo "It's green? Run it again with a release flag"
 echo "Did it succeed? Great. Let's continue with tagging and more"
 read -p "Press enter to continue"
 
-
-
-echo "Old version is $oldver"
-echo "Let's tag the release"
-
 oldver=`cat package.json  | grep "\"version\":" | cut -f 2 -d ":" | sed 's/"//g' | sed 's/,//g' | awk '{$1=$1};1'`
 oldVerUnderscore=`echo $oldver | sed 's/\./_/g'`
 vOldVerUnderscoreFinal=v$oldVerUnderscore.Final
+
+echo "Old version is $oldver"
+echo "Let's tag the release"
 git tag $vOldVerUnderscoreFinal
 if [ "$debug" -eq 0 ]; then
 	git push origin $vOldVerUnderscoreFinal


### PR DESCRIPTION
Fixes #637

## Summary
- Fix release script displaying empty version variable
- Move variable assignments before echo statement

## Problem
The script was trying to echo `$oldver` before it was assigned, resulting in:
```
Old version is 
Let's tag the release
```

## Solution
Moved the variable assignments (lines 67-69) to before the echo statement (line 64) so the version is extracted from `package.json` before being displayed.

## Test plan
- Run the release script and verify it now displays:
```
Old version is 0.26.21
Let's tag the release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)